### PR TITLE
Release 2022.5

### DIFF
--- a/Simplists.xcodeproj/project.pbxproj
+++ b/Simplists.xcodeproj/project.pbxproj
@@ -1259,7 +1259,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2022.4;
+				MARKETING_VERSION = 2022.5;
 				PRODUCT_BUNDLE_IDENTIFIER = com.sleekible.Simplists.debug.SimplistsWidget;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -1288,7 +1288,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2022.4;
+				MARKETING_VERSION = 2022.5;
 				PRODUCT_BUNDLE_IDENTIFIER = com.sleekible.Simplists.SimplistsWidget;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -1436,7 +1436,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2022.4;
+				MARKETING_VERSION = 2022.5;
 				PRODUCT_BUNDLE_IDENTIFIER = com.sleekible.Simplists.debug;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTS_MACCATALYST = YES;
@@ -1462,7 +1462,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2022.4;
+				MARKETING_VERSION = 2022.5;
 				PRODUCT_BUNDLE_IDENTIFIER = com.sleekible.Simplists;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTS_MACCATALYST = YES;
@@ -1486,7 +1486,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2022.4;
+				MARKETING_VERSION = 2022.5;
 				PRODUCT_BUNDLE_IDENTIFIER = com.sleekible.Simplists.debug.watchkitapp.watchkitextension;
 				PRODUCT_NAME = "${TARGET_NAME}";
 				SDKROOT = watchos;
@@ -1512,7 +1512,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2022.4;
+				MARKETING_VERSION = 2022.5;
 				PRODUCT_BUNDLE_IDENTIFIER = com.sleekible.Simplists.watchkitapp.watchkitextension;
 				PRODUCT_NAME = "${TARGET_NAME}";
 				SDKROOT = watchos;
@@ -1535,7 +1535,7 @@
 				DEVELOPMENT_TEAM = 25V97QMNV5;
 				IBSC_MODULE = WatchApp_Extension;
 				INFOPLIST_FILE = WatchApp/Info.plist;
-				MARKETING_VERSION = 2022.4;
+				MARKETING_VERSION = 2022.5;
 				PRODUCT_BUNDLE_IDENTIFIER = com.sleekible.Simplists.debug.watchkitapp;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = watchos;
@@ -1557,7 +1557,7 @@
 				DEVELOPMENT_TEAM = 25V97QMNV5;
 				IBSC_MODULE = WatchApp_Extension;
 				INFOPLIST_FILE = WatchApp/Info.plist;
-				MARKETING_VERSION = 2022.4;
+				MARKETING_VERSION = 2022.5;
 				PRODUCT_BUNDLE_IDENTIFIER = com.sleekible.Simplists.watchkitapp;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = watchos;
@@ -1586,7 +1586,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 2022.4;
+				MARKETING_VERSION = 2022.5;
 				PRODUCT_BUNDLE_IDENTIFIER = com.sleekible.SimplistsKit.debug;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
@@ -1618,7 +1618,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 2022.4;
+				MARKETING_VERSION = 2022.5;
 				PRODUCT_BUNDLE_IDENTIFIER = com.sleekible.SimplistsKit;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
@@ -1647,7 +1647,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2022.4;
+				MARKETING_VERSION = 2022.5;
 				PRODUCT_BUNDLE_IDENTIFIER = com.sleekible.Simplists.debug.SimplistsIntentHandler;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -1675,7 +1675,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2022.4;
+				MARKETING_VERSION = 2022.5;
 				PRODUCT_BUNDLE_IDENTIFIER = com.sleekible.Simplists.SimplistsIntentHandler;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;

--- a/Simplists/Sources/Views/FocusableTextField.swift
+++ b/Simplists/Sources/Views/FocusableTextField.swift
@@ -111,6 +111,8 @@ struct FocusableTextField: UIViewRepresentable {
     }
 
     func updateUIView(_ uiView: UITextField, context: Context) {
+        let selectedRange = uiView.selectedTextRange
         uiView.attributedText = NSAttributedString(string: text, attributes: textAttributes)
+        uiView.selectedTextRange = selectedRange
     }
 }

--- a/Simplists/en.lproj/Localizable.strings
+++ b/Simplists/en.lproj/Localizable.strings
@@ -51,14 +51,14 @@
 "privacy-changes-header-text" = "Changes to This Policy";
 "privacy-commitment-body-text" = "Your privacy is important to us. To protect that privacy, we provide this notice to explain our information collection practices.";
 "privacy-commitment-header-text" = "Our Commitment to Privacy";
-"privacy-contact-us-body-text" = "Should you have other questions or concerns about this privacy policy, please email snaplists@sleekible.com. At this time, we only have the ability to receive and send English-language communications.";
+"privacy-contact-us-body-text" = "Should you have questions or concerns about this privacy policy, please email snaplists@sleekible.com. At this time, we only have the ability to receive and send English-language communications.";
 "privacy-contact-us-header-text" = "How to Contact Us";
 "privacy-data-body-text" = "The Snaplists app does not collect any user information. There is no sign-up, sign-in, or opportunity in the app to give us your personal information.  The app uses Apple’s iCloud service to sync your lists across your devices.  We cannot see your data:  your lists, the list title, the items on the list, even the number of lists you create in the app.  We cannot view any of this data.";
 "privacy-data-header-text" = "Your Data is Private";
 "privacy-effective-date-text" = "Effective Date: February 7, 2021";
 "privacy-external-services-body-text" = "The Snapslists app does not use any 3rd party/external services.  There are no analytics gathering, behavior tracking, etc.  This app uses only Apple-provided APIs and frameworks.";
 "privacy-external-services-header-text" = "No External Services";
-"privacy-feedback-body-text" = "The app does provide a feedback feature to allow you to provide us feedback about the app. This feature opens a simple email to us. Be aware that by sending the email, you are giving us your email address. We do not use this email address for anything other than responding to your feedback, via email.  If you prefer, you can tweet us at @snaplistsapp.";
+"privacy-feedback-body-text" = "The app does provide a feedback feature to allow you to provide us feedback about the app. This feature opens a simple email to us. Be aware that by sending the email, you are giving us your email address. We do not use this email address for anything other than responding to your feedback, via email.";
 "privacy-feedback-header-text" = "In-App Feedback";
 "Purchase is pending approval." = "Purchase is pending approval.";
 "Purchased" = "Purchased";

--- a/SimplistsWidget/Views/ListsWidget/LargeListsWidgetView.swift
+++ b/SimplistsWidget/Views/ListsWidget/LargeListsWidgetView.swift
@@ -12,7 +12,7 @@ struct LargeListsWidgetView: View {
     var lists: [ListDetail]
 
     var body: some View {
-        ListsView(lists: lists, maxVisibleListCount: 10)
+        ListsView(lists: lists, maxVisibleListCount: 8)
     }
 }
 


### PR DESCRIPTION
- Fixed [a bug](https://github.com/tomhartnett/Snaplists/issues/14) with the cursor jumping to the end of text in a text field while editing.
- Changed the number of visible items on the large widget to avoid clipping content.
- Updated privacy policy in the app to remove references to defunct Twitter account.
